### PR TITLE
Add testthat setup and Doc2Df unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 CBR
 ===
-Получить данные с [технических ресурсов Банка России](http://www.cbr.ru/scripts/root.asp)  
-Functions to get data from web-services of cbr.ru (http://www.cbr.ru/scripts/Root.asp) from Bank of Russia (Банк России), Russia's central bank 
+Получить данные с [технических ресурсов Банка России](http://www.cbr.ru/scripts/root.asp)
+Functions to get data from web-services of cbr.ru (http://www.cbr.ru/scripts/Root.asp) from Bank of Russia (Банк России), Russia's central bank
+
+## Тесты
+Для запуска тестов потребуется установленный `R` и пакет `testthat`.
+Запустите их из корня репозитория командой:
+
+```sh
+Rscript tests/testthat.R
+```

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,2 @@
+library(testthat)
+test_dir('tests/testthat')

--- a/tests/testthat/test-doc2df.R
+++ b/tests/testthat/test-doc2df.R
@@ -1,0 +1,32 @@
+library(testthat)
+
+# helper to load Doc2Df without sourcing full script
+load_doc2df <- function() {
+  lines <- readLines(file.path("..", "..", "codes_new", "CBR_web.R"))
+  start <- grep("^Doc2Df <-", lines)[1]
+  count_pattern <- function(x, pattern) {
+    res <- gregexpr(pattern, x, fixed = TRUE)[[1]]
+    sum(res != -1)
+  }
+  braces <- 0
+  end <- start
+  repeat {
+    braces <- braces + count_pattern(lines[end], "{") - count_pattern(lines[end], "}")
+    if (braces == 0) break
+    end <- end + 1
+  }
+  code <- paste(lines[start:end], collapse = "\n")
+  eval(parse(text = code), envir = .GlobalEnv)
+}
+
+load_doc2df()
+
+
+test_that("Doc2Df converts xml to data frame", {
+  xml_text <- "<root><row><a>1</a><b>2</b></row><row><a>3</a><b>4</b></row></root>"
+  library(XML)
+  doc <- xmlInternalTreeParse(xml_text)
+  df <- Doc2Df(doc, "row")
+  expect_equal(names(df), c("a", "b"))
+  expect_equal(nrow(df), 2)
+})


### PR DESCRIPTION
## Summary
- add a minimal testthat infrastructure
- implement a test for `Doc2Df`
- document how to run tests in README

## Testing
- `Rscript tests/testthat.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cdda4568832483827e121880065a